### PR TITLE
fix: put referenced images in the image list of bundle.json

### DIFF
--- a/arm-aci/bundle.json
+++ b/arm-aci/bundle.json
@@ -3,11 +3,17 @@
     "version": "0.1.0",
     "invocationImages": [
         {
-        "imageType": "docker",
-        "image": "technosophos/arm-aci:0.1.0"
+            "imageType": "docker",
+            "image": "technosophos/arm-aci:0.1.0"
         }
     ],
-    "images": [],
+    "images": [
+        {
+            "imageType": "docker",
+            "image": "microsoft/aci-helloworld",
+            "digest": "sha256:a3b2eb140e6881ca2c4df4d9c97bedda7468a5c17240d7c5d30a32850a2bc573"
+        }
+    ],
     "parameters": {
         "azure_resource_group": {
             "defaultValue": "armbase-default",

--- a/compose/bundle.json
+++ b/compose/bundle.json
@@ -3,11 +3,22 @@
     "version": "0.1.0",
     "invocationImages": [
         {
-        "imageType": "docker",
-        "image": "cnab/compose:latest"
+            "imageType": "docker",
+            "image": "cnab/compose:latest"
         }
     ],
-    "images": [],
+    "images": [
+        {
+            "imageType": "docker",
+            "image": "wordpress:4.9.8-apache",
+            "digest": "sha256:7121cdf8e9f01816653a3b2d2f4fc7bfe1dab956f00db5c7e7689e5f1454029a"
+        },
+        {
+            "imageType": "docker",
+            "image": "mysql:5.7",
+            "digest": "sha256:1d8f471c7e2929ee1e2bfbc1d16fc8afccd2e070afed24805487e726ce601a6d"
+        }
+    ],
     "parameters": {},
     "credentials": {}
 }


### PR DESCRIPTION
This adds imges to the bundle.json for ACI-ARM and for docker-compose