### PR TITLE
fix(bundles,wordpress): change bundle name to match its .json filename

### DIFF
--- a/bundles/wordpress.json
+++ b/bundles/wordpress.json
@@ -1,5 +1,5 @@
 {
-    "name": "wordpress-bundle",
+    "name": "wordpress",
     "version": "0.1.0",
     "invocationImage": {
         "imageType": "docker",

--- a/wordpress/cnab/bundle.json
+++ b/wordpress/cnab/bundle.json
@@ -1,5 +1,5 @@
 {
-    "name": "wordpress-bundle",
+    "name": "wordpress",
     "version": "0.1.0",
     "invocationImage": {
         "imageType": "docker",


### PR DESCRIPTION
Previously, `duffle search` showed a bundle named `wordpress-bundle`.  However, attempted installation using this name would fail, as the bundle .json itself is named `wordpress.json` in the `bundles` directory.