### PR TITLE
fix: pulumi bundle now has images section

### DIFF
--- a/pulumibase/bundle.json
+++ b/pulumibase/bundle.json
@@ -7,5 +7,11 @@
         "image": "cnab/pulumibase:latest"
         }
     ],
-    "images": []
+    "images": [
+        {
+            "description": "image called from within Pulumi script",
+            "imageType": "docker",
+            "image": "nginx:latest"
+        }
+    ]
 }


### PR DESCRIPTION
It's debatable whether this is necessary, since (a) Pulumi doesn't reference a specific tag, and (b) ref replacement doesn't really work on Pulumi scripts