### PR TITLE
fixed hellohelm to remove namespacing from app

### DIFF
--- a/hellohelm/cnab/app/Makefile
+++ b/hellohelm/cnab/app/Makefile
@@ -14,7 +14,7 @@ install:
 
 uninstall: 
 	@echo "Do Uninstall"
-	helm delete --purge --namespace $(CNAB_P_NAMESPACE) $(CNAB_INSTALLATION_NAME)
+	helm delete --purge $(CNAB_INSTALLATION_NAME)
 
 upgrade:
 	@echo "Do Upgrade"
@@ -22,6 +22,6 @@ upgrade:
 
 status:
 	@echo "Do Status"
-	helm status --namespace $(CNAB_P_NAMESPACE) $(CNAB_INSTALLATION_NAME)
+	helm status $(CNAB_INSTALLATION_NAME)
 
 .PHONY: install uninstall upgrade status


### PR DESCRIPTION
two helm commands fail on cnab activities because helm does not take a namespace option for delete and status. 