### PR TITLE
Grammar fix: "echo uninstall" -> "echo Uninstall"

### DIFF
--- a/helloworld/cnab/app/run
+++ b/helloworld/cnab/app/run
@@ -11,7 +11,7 @@ case $action in
     echo "Install action"
     ;;
     uninstall)
-    echo "uninstall action"
+    echo "Uninstall action"
     ;;
     upgrade)
     echo "Upgrade action"


### PR DESCRIPTION
This was the only output line which did not capitalize the first word.