### PR TITLE
fix(validation): (always) fetch latest schema before validation

### DIFF
--- a/Dockerfile.ajv
+++ b/Dockerfile.ajv
@@ -1,11 +1,3 @@
 FROM node:8-alpine
 
-ARG json_schema_file
-ARG json_schema_uri
-
 RUN npm install -g ajv-cli
-
-RUN wget -q \
-  --header 'Accept: application/vnd.github.v3.raw' \
-  -O ${json_schema_file} \
-  ${json_schema_uri}


### PR DESCRIPTION
Fetching the schema in the form of a `RUN` step in the corresponding Dockerfile was not sufficient, as this layer would be cached.  Rather, we should fetch it always before running validation.