### PR TITLE
removes sign-local from build step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ ifndef BUNDLE
 endif
 
 .PHONY: build
-build: docker-build sign-local
+build: docker-build
 
 .PHONY: docker-build
 docker-build:


### PR DESCRIPTION
fixes error in build step

```
$ BUNDLE=helloworld VERSION=latest make build
docker build -t cnab/helloworld:latest helloworld/cnab
[+] Building 0.1s (9/9) FINISHED                                                                                                                                                  
 => [internal] load build definition from Dockerfile                                                                                                                         0.0s
 => => transferring dockerfile: 145B                                                                                                                                         0.0s
 => [internal] load .dockerignore                                                                                                                                            0.0s
 => => transferring context: 2B                                                                                                                                              0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                                             0.0s
 => [1/3] FROM docker.io/library/alpine:latest                                                                                                                               0.0s
 => [internal] helper image for file operations                                                                                                                              0.0s
 => [internal] load build context                                                                                                                                            0.0s
 => => transferring context: 668B                                                                                                                                            0.0s
 => CACHED [2/3] COPY app/run /cnab/app/run                                                                                                                                  0.0s
 => CACHED [3/3] COPY Dockerfile cnab/Dockerfile                                                                                                                             0.0s
 => exporting to image                                                                                                                                                       0.0s
 => => exporting layers                                                                                                                                                      0.0s
 => => writing image sha256:42562b9a08384192a770e2c24a75cc6d38afd9922db9eae5feb156622eb62699                                                                                 0.0s
 => => naming to docker.io/cnab/helloworld:latest                                                                                                                            0.0s
make: *** No rule to make target `sign-local', needed by `build'.  Stop.
```