### PR TITLE
Fix aks bundle

### DIFF
--- a/aks/README.md
+++ b/aks/README.md
@@ -3,6 +3,22 @@
 
 This bundle creates an AKS cluster, configures helm with RBAC, installs an nginx-ingress-controller, installs kube-lego for certificate management, and modifies your domain to point to the newly provisioned nginx ingress controller service IP address.
 
+## Prerequisites
+- Azure account
+- Requires a [DNS name](https://docs.microsoft.com/en-us/azure/dns/dns-getstarted-portal) that can be used to assign an IP
+    - the bash script assumes that is the same as the `$RESOURCE_GROUP` set in `bundle.json`
+    - make sure you create this resource group and DNS zone beforehand
+- Docker installed
+- `duffle` binary and `make` utility
+
+```bash
+$ az login
+$ cd ~/workspace/example-bundles # the root of the repo
+$ duffle creds generate -f ./aks/bundle.json example-aks-creds
+$ sudo docker build -t cnab/aks:latest aks/cnab --no-cache
+$ sudo duffle install my-aks -f aks/bundle.json -c example-aks-creds
+```
+
 ## Credentials
 By default, the `example-aks-credentials.yaml` file and the `run` script are configured to mount the necessary pieces to the authenticate to Azure. Another route to take is to configure a service principal. The necessary `az account login` line is included but commented out in the `run` script if you choose to use this in non-demo environment.
 

--- a/aks/cnab/Dockerfile
+++ b/aks/cnab/Dockerfile
@@ -12,10 +12,12 @@ RUN apk add --update ca-certificates \
  && rm /var/cache/apk/* \
  && rm -f /helm-${HELM_LATEST_VERSION}-linux-amd64.tar.gz \
  && apk update && \
-  apk add bash py-pip && \
-  apk add --virtual=build gcc libffi-dev musl-dev openssl-dev python-dev make && \
-  pip install --upgrade pip && \
-  pip install azure-cli
+  apk add bash py3-pip && \
+  apk add --virtual=build gcc libffi-dev musl-dev openssl-dev python3-dev make && \
+  pip3 install --upgrade pip && \
+  pip3 install --upgrade requests && \
+  pip3 install azure-cli && \
+  ln -s /usr/bin/python3 /usr/bin/python
 
 COPY app/run /cnab/app/run
 COPY app/rbac-config.yaml /cnab/app/rbac-config.yaml

--- a/aks/cnab/app/run
+++ b/aks/cnab/app/run
@@ -51,7 +51,7 @@ case $action in
         echo 'End point ready:' && echo $external_ip
 
         echo "Creating a DNS a record to point domain at nginx loadbalancer"
-        az network dns record-set a add-record --resource-group duffle-demo --zone-name $DOMAIN --record-set-name @ --ipv4-address $external_ip
+        az network dns record-set a add-record --resource-group $RESOURCE_GROUP --zone-name $DOMAIN --record-set-name @ --ipv4-address $external_ip
         echo "$DOMAIN now points to $external_ip"
 
         echo "Installing kube-lego to manage certificates"


### PR DESCRIPTION
I tried installing this on a Ubuntu 16.04 x64 and got bunch of errors. I managed to make this run by bumping up to python3 (also python2 will [be retired](https://pythonclock.org/) soon).

Also included some prerequisites specific to this bundle in the README.